### PR TITLE
Add a deployment step to publish on a green master build

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -4,6 +4,8 @@ machine:
   environment:
     YARN_VERSION: 0.18.1
     PATH: "${PATH}:${HOME}/.yarn/bin:${HOME}/${CIRCLE_PROJECT_REPONAME}/node_modules/.bin"
+    AWS_DEFAULT_REGION: us-east-1
+    AWS_LAMBDA_PRODUCTION_ARN: arn:aws:lambda:us-east-1:750878068186:function:mtaStatus
 
 dependencies:
   pre:
@@ -23,3 +25,11 @@ dependencies:
 test:
   override:
     - yarn test
+
+deployment:
+  master:
+    branch: master
+    commands:
+      - yarn release
+      - aws lambda update-function-code --function-name $AWS_LAMBDA_PRODUCTION_ARN --zip-file subway.zip
+      - aws lambda publish-version --function-name mtaStatus  --description $CIRCLE_SHA1 || "" || $CIRCLE_COMPARE_URL


### PR DESCRIPTION
## What
This adds Circle commands to do these steps on a `master` green build:

1. Build a release artifact 
2. Uses `update-function-code` on aws-cli to upload the code to `$LATEST` 
3. Uses `publish-version` on aws-cli to publish a version from `$LATEST`

Then we can point the alias `Production` (which is what is used by the skill in production) to the right version.

![alias_intro_2_10](https://cloud.githubusercontent.com/assets/1251946/22857468/83e81938-f073-11e6-8b53-374b3b2b8392.png)


http://docs.aws.amazon.com/lambda/latest/dg/versioning-aliases.html

Post deploy, you can then change the Production alias to point to the new version: 

<img width="1254" alt="screen shot 2017-02-11 at 4 13 03 pm" src="https://cloud.githubusercontent.com/assets/1251946/22857540/13286020-f075-11e6-94bc-6930dfa4ea66.png">


## Prerequisites
- [x] Setting up an IAM user on AWS that has scoped access to Lambda
- [x] Setting up the IAM user's AWS creds on CircleCI 
